### PR TITLE
chore(gha): migrate Jenkins to GitHub Actions

### DIFF
--- a/.ci.infra
+++ b/.ci.infra
@@ -1,2 +1,0 @@
-@Library("camunda-ci") _
-camundaPipeline()

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,136 @@
+name: Build and Deploy
+
+on:
+  push:
+
+env:
+  IMAGE_NAME: camunda-internal/camunda_int-hapdfy
+  STAGE_BRANCH: master
+  PROD_BRANCH: live
+
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-latest
+    outputs:
+      image_digest: ${{ steps.image.outputs.image_digest }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2.5.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/infra/ci/common BUILDER_INT_TO_K8S_INTERNAL | GCP_CREDENTIALS;
+          secret/data/github.com/organizations/camunda NEXUS_USR;
+          secret/data/github.com/organizations/camunda NEXUS_PSW;
+    - name: Login to Harbor Registry for dependencies
+      uses: docker/login-action@v2
+      with:
+        registry: registry.camunda.cloud
+        username: ${{ steps.secrets.outputs.NEXUS_USR }}
+        password: ${{ steps.secrets.outputs.NEXUS_PSW }}
+    # Overwrite push behaviour to always push images of prod and stage
+    # Define Environment, used for Docker Build
+    - run: |
+        if [[ ${{ github.ref }} == 'refs/heads/${{ env.STAGE_BRANCH }}' || ${{ github.ref }} == 'refs/heads/${{ env.PROD_BRANCH }}' ]];
+        then
+          echo "FOFCE_PUSH=true" >> "$GITHUB_ENV"
+        else
+          echo "FORCE_PUSH=false" >> "$GITHUB_ENV"
+        fi
+
+        if [[ ${{ github.ref }} == 'refs/heads/${{ env.PROD_BRANCH }}' ]];
+        then
+          echo "ENVIRONMENT=prod" >> "$GITHUB_ENV"
+        else
+          echo "ENVIRONMENT=stage" >> "$GITHUB_ENV"
+        fi
+    - uses: camunda/infra-global-github-actions/build-docker-image@main
+      id: image
+      with:
+        build_args: |
+          NEXUS_USR=${{ steps.secrets.outputs.NEXUS_USR }}
+          NEXUS_PSW=${{ steps.secrets.outputs.NEXUS_PSW }}
+          ENVIRONMENT=${{ env.ENVIRONMENT }}
+        registry_host: gcr.io
+        registry_username: _json_key
+        registry_password: ${{ steps.secrets.outputs.GCP_CREDENTIALS }}
+        image_name: ${{ env.IMAGE_NAME }}
+        extra_tags: |
+          type=sha,prefix={{branch}}-,format=long
+        force_push: ${{ env.FOFCE_PUSH }}
+
+  kubernetes-replace-image:
+    runs-on: ubuntu-latest
+    needs: [build-docker-image]
+    # replace images either on STAGE_BRANCH = stage env or PROD_BRANCH = prod env
+    # env is not part of job.if, therefore has to manually be supplied
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/live'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2.5.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/infra/ci/common BUILDER_INT_TO_K8S_INTERNAL | GCP_CREDENTIALS;
+    - run: |
+        if [[ ${{ github.ref }} == 'refs/heads/${{ env.STAGE_BRANCH }}' ]];
+        then
+          echo "ENV_SUFFIX=-stage" >> "$GITHUB_ENV"
+        else
+          echo "ENV_SUFFIX=" >> "$GITHUB_ENV"
+        fi
+    - uses: azure/setup-kubectl@v3
+    - name: GCloud Auth
+      id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: '${{ steps.secrets.outputs.GCP_CREDENTIALS }}'
+    - id: get-credentials
+      uses: 'google-github-actions/get-gke-credentials@v1'
+      with:
+        cluster_name: camunda-int${{ env.ENV_SUFFIX }}
+        location: europe-west1
+    - uses: camunda/infra-global-github-actions/kubernetes-image-replace@main
+      with:
+        app_name: hapdfy-int-camunda-com
+        app_type: deployment
+        container_name: main
+        image: gcr.io/${{ env.IMAGE_NAME }}@${{ needs.build-docker-image.outputs.image_digest }}
+        namespace: hapdfy
+
+  notify-on-failure:
+    needs: [build-docker-image, kubernetes-replace-image]
+    if: ${{ failure() }}  # only runs if there's a failure in the workflow
+    runs-on: ubuntu-latest
+    steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2.5.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false  # we rely on step outputs, no need for environment variables
+        secrets: |
+          secret/data/products/internal-apps/ci/common SLACK_WEBHOOK_ALERTS;
+    - name: Send Slack notification
+      uses: 8398a7/action-slack@v3
+      with:
+        status: failure
+        channel: '#internal-apps-alerts'
+        fields: repo,message,commit,author,action,eventName,ref,workflow
+      env:
+        SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_WEBHOOK_ALERTS }}


### PR DESCRIPTION
- related to https://github.com/camunda/team-infrastructure/issues/150

Transforms the previous `camundaPipeline` into a GitHub action.
It contains only reuseable blocks, that's why I decided against creating more composable actions since they'd already be very limited as a lot of it is secret retrieval.

Behaviour is the same:
- On push, build image but not push
- If master, push image and replace image in cluster (stage) to "update" it.
- If live, push image and replace image in cluster (prod)

I decided to use the image's digest, which will always result in a restart. This is also the current behaviour except that currently the image isn't updated but just the pod restarted.

Example run of building the image:
https://github.com/camunda/int-haPDFy/actions/runs/4142661564